### PR TITLE
various fixes

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -24,6 +24,8 @@ WORKDIR /apps
 
 COPY --chown=node:node . .
 
+RUN chown -R node: /apps
+
 RUN sed -n 's/^\(.*\)=.*$/\1=__\1__/p' .env-example > .env.production.local && \
     cat .env.production.local | \
         xargs -I{} bash -c "echo '{}' | sed 's/^\\(.*\\)=.*$/\\1/' >> /srv/env.var.list"

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,29 +1,39 @@
-FROM ubuntu:18.04 as builder
+################################################################
+
+ARG NODE_VERSION=hydrogen
+ARG NODE_CONTAINER_TAG=${NODE_VERSION}-bullseye-slim
+
+################################################################
+
+FROM node:${NODE_CONTAINER_TAG} as builder
+
+################################################################
+
+USER root
+RUN npm i -g npm
+
+################################################################
 
 # Install any needed packages
 RUN apt-get update && \
-  apt-get install --no-install-recommends -y curl git gnupg ca-certificates python3 pkg-config make cmake g++ libudev-dev libusb-1.0-0-dev
+    apt-get install --no-install-recommends -y curl git gnupg ca-certificates python3 pkg-config make cmake g++ libudev-dev libusb-1.0-0-dev
 
-# install nodejs
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt-get install --no-install-recommends -y nodejs && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
-RUN npm install yarn -g
+################################################################
 
 WORKDIR /apps
-COPY . .
+
+COPY --chown=node:node . .
 
 RUN sed -n 's/^\(.*\)=.*$/\1=__\1__/p' .env-example > .env.production.local && \
-    echo 'APP_NAME=__APP_NAME__' >> .env.production.local && \
-    echo 'RPC_HOSTNAME=__RPC_HOSTNAME__' >> .env.production.local && \
-    echo 'UI_COLOR=__UI_COLOR__' >> .env.production.local && \
     cat .env.production.local | \
         xargs -I{} bash -c "echo '{}' | sed 's/^\\(.*\\)=.*$/\\1/' >> /srv/env.var.list"
 
+USER node
+
 RUN yarn && NODE_ENV=production yarn build:www
 
-# ===========================================================
+################################################################
+
 FROM nginx:stable-alpine
 
 # The following is mainly for doc purpose to show which ENV is supported
@@ -51,3 +61,5 @@ EXPOSE 80
 CMD replace-env-var-placeholders.sh && \
     /usr/share/nginx/html/env.sh && \
     nginx -g 'daemon off;'
+
+################################################################

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "wrangler:testnet:publish": "yarn run build:www && cd packages/apps && npx wrangler publish --env testnet"
   },
   "devDependencies": {
-    "@cloudflare/wrangler": "^1.10.3",
     "@crustio/crust-pin": "^1.0.0",
     "@pinata/sdk": "^2.1.0",
     "@polkadot/dev": "^0.72.32",

--- a/packages/apps/webpack.config.cjs
+++ b/packages/apps/webpack.config.cjs
@@ -19,13 +19,14 @@ module.exports = merge(
     output: {
       crossOriginLoading: 'anonymous'
     },
-    plugins: [
+    plugins: (process.env.SUBRESOURCE_INTEGRITY_PLUGIN ? [
       new SubresourceIntegrityPlugin(),
+    ] : []).concat([
       new HtmlWebpackPlugin({
         PAGE_TITLE: 'Polymesh App',
         minify: false,
         template: path.join(context, `${hasPublic ? 'public/' : ''}index.html`)
-      })
-    ]
+      }),
+    ]),
   }
 );

--- a/packages/react-components/src/styles/index.ts
+++ b/packages/react-components/src/styles/index.ts
@@ -20,7 +20,7 @@ const FACTORS = [0.2126, 0.7152, 0.0722];
 const PARTS = [0, 2, 4];
 const VERY_DARK = 16;
 
-//const defaultHighlight = '#f19135';
+// const defaultHighlight = '#f19135';
 
 /* replace template placeholder with default value if not overridden at run-time */
 const defaultHighlight = /^_{2}UI_COLOR_{2}$/.test('__UI_COLOR__') ? '#f19135' : '__UI_COLOR__';

--- a/packages/react-components/src/styles/index.ts
+++ b/packages/react-components/src/styles/index.ts
@@ -20,7 +20,10 @@ const FACTORS = [0.2126, 0.7152, 0.0722];
 const PARTS = [0, 2, 4];
 const VERY_DARK = 16;
 
-const defaultHighlight = '#f19135';
+//const defaultHighlight = '#f19135';
+
+/* replace template placeholder with default value if not overridden at run-time */
+const defaultHighlight = /^_{2}UI_COLOR_{2}$/.test('__UI_COLOR__') ? '#f19135' : '__UI_COLOR__';
 
 function getHighlight (uiHighlight: string | undefined): string {
   return (uiHighlight || defaultHighlight);

--- a/packages/react-components/src/styles/index.ts
+++ b/packages/react-components/src/styles/index.ts
@@ -23,7 +23,7 @@ const VERY_DARK = 16;
 // const defaultHighlight = '#f19135';
 
 /* replace template placeholder with default value if not overridden at run-time */
-const defaultHighlight = /^_{2}UI_COLOR_{2}$/.test('__UI_COLOR__') ? '#f19135' : '__UI_COLOR__';
+const defaultHighlight = /^(_{2}UI_COLOR_{2})?$/.test('__UI_COLOR__') ? '#f19135' : '__UI_COLOR__';
 
 function getHighlight (uiHighlight: string | undefined): string {
   return (uiHighlight || defaultHighlight);

--- a/packages/react-components/src/styles/theme.ts
+++ b/packages/react-components/src/styles/theme.ts
@@ -7,7 +7,10 @@ export const colorBtnDefault = '#767778';
 export const colorBtnShadow = '#98999a';
 
 /* highlighted buttons, orange */
-export const colorBtnHighlight = '#f19135';
+//export const colorBtnHighlight = '#f19135';
+
+/* replace template placeholder with default value if not overridden at run-time */
+export const colorBtnHighlight = /^_{2}UI_COLOR_{2}$/.test('__UI_COLOR__') ? '#f19135' : '__UI_COLOR__';
 
 /* primary buttons, blue */
 export const colorBtnPrimary = colorBtnDefault; // '#2e86ab';

--- a/packages/react-components/src/styles/theme.ts
+++ b/packages/react-components/src/styles/theme.ts
@@ -7,7 +7,7 @@ export const colorBtnDefault = '#767778';
 export const colorBtnShadow = '#98999a';
 
 /* highlighted buttons, orange */
-//export const colorBtnHighlight = '#f19135';
+// export const colorBtnHighlight = '#f19135';
 
 /* replace template placeholder with default value if not overridden at run-time */
 export const colorBtnHighlight = /^_{2}UI_COLOR_{2}$/.test('__UI_COLOR__') ? '#f19135' : '__UI_COLOR__';

--- a/packages/react-components/src/styles/theme.ts
+++ b/packages/react-components/src/styles/theme.ts
@@ -10,7 +10,7 @@ export const colorBtnShadow = '#98999a';
 // export const colorBtnHighlight = '#f19135';
 
 /* replace template placeholder with default value if not overridden at run-time */
-export const colorBtnHighlight = /^_{2}UI_COLOR_{2}$/.test('__UI_COLOR__') ? '#f19135' : '__UI_COLOR__';
+export const colorBtnHighlight = /^(_{2}UI_COLOR_{2})?$/.test('__UI_COLOR__') ? '#f19135' : '__UI_COLOR__';
 
 /* primary buttons, blue */
 export const colorBtnPrimary = colorBtnDefault; // '#2e86ab';


### PR DESCRIPTION
- updates nodejs to current LTS (`v18`); use upstream docker image, which fixes a combined delay of 100 seconds due to several `sleep` introduced by `deb.nodesource.com`:
```
  This script, located at https://deb.nodesource.com/setup_14.x, used to
  install Node.js is deprecated now and will eventually be made inactive.
```
- enables customization of `ui.color` regardless of the specific type of chain environment; prevents the default `#f19135` (orange) colour being forced by the application for staging/testnet
- fixes: `EACCES: permission denied, mkdir '/apps/node_modules'`
- sets `@cloudflare/wrangler` package to optional by leaving only the `optionalDependencies` entry for it; fixes build error related to a cloudflare dependency that is not utilized in a production environment
- parameterizes webpack plugins